### PR TITLE
admin側からの商品検索

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,9 +21,9 @@ class ProductsController < ApplicationController
 
   def show
   	@product = Product.find(params[:id])
-    # if admin_signed_in?
-    #   redirect_to admins_product_path(@product)
-    # else
+    if admin_signed_in?
+      redirect_to admins_product_path(@product)
+    else
       @cartitem = CartItem.new
       @q = Product.includes(:discs,:musics).ransack(params[:q])
 


### PR DESCRIPTION
・admin側から商品検索をすると、なぜかuser側の商品詳細ページに飛んでしまう問題を修正中です。
・削除したuserの情報を残しておく(論理削除)の問題も現在取り組み中です。