### PR TITLE
論理削除+admin側体裁

### DIFF
--- a/app/assets/stylesheets/admins/orders.scss
+++ b/app/assets/stylesheets/admins/orders.scss
@@ -12,79 +12,14 @@ a:hover{
 	text-decoration: underline overline;
 }
 
-.border-solid-1{
-	border: solid 1px;
-	border-radius: 5px;
-}
-.user-infomation{
-	width: 90%;
-	margin: 0 auto;
-	border: solid 1px;
-	border-radius: 5px;
-	padding: 20px;
-}
-.order-infomation{
-	width: 90%;
-	margin: 0 auto;
-}
-.order-show-user-box{
-	width: 300px;
-	height: 200px;
-	border: solid 1px;
-	margin: 10px;
-	border-radius: 5px;
-}
-.border-bottom{
-	width: 100%;
-	padding:10px;
-	border-bottom: solid 1px;
-	display: flex;
-	flex-direction: row;
-}
-.order-info2{
-	width: 200px;
-	justify-content: space-between;
-}
-.order-status2{
-	width: 300px;
-	justify-content: space-between;
-}
-.admin-product-show-total{
-	display: flex;
-	flex-direction: row;
-	/*background-color: silver;*/
-}
-.address-box{
-	justify-content: space-between;
-	width: 50%;
-	border: solid 1px;
-	border-radius: 5px;
-}
-.total-box{
-	justify-content: space-between;
-	width: 50%;
-  	border: solid 1px;
-	border-radius: 5px;
-	font-size: 20px;
-	padding: 20px;
-}
-
-/*--オーダー一覧--*/
-.ad-order-index-box {
+/*--index--*/
+/*.ad-order-index-box {
 	width: 80%;
 	margin: 30px auto;
 	display: flex;
 	flex-direction: row;
 	justify-content: center;
-}
-.ad-or-index-box {
-	width: 70%;
-	margin: 10px;
-	padding-bottom: 30px;
-	border: solid 1px;
-	border-radius: 50px;
-	justify-content: center;
-}
+}*/
 .extraction-box {
 	width: 30%;
 	margin: 10px;
@@ -96,8 +31,94 @@ a:hover{
 }
 .status-box {
 	margin-top: 30px;
+	margin-bottom: 20px;
 }
-.box_for_position {
+.box-for-position {
 	position: fixed;
 	margin-left: 40px;
+}
+
+/*--show--*/
+.ad-order-show-box {
+	width: 80%;
+	margin: 30px auto;
+/*	display: flex;*/
+	justify-content: center;
+}
+.ad-order-show-inner {
+	float: left;
+	width: 70%;
+	margin: 50px auto;
+	padding-bottom: 30px;
+	border: solid 1px;
+	border-radius: 50px;
+	justify-content: center;
+}
+/*.ad-order-head {
+	width: 60%;
+	margin: 0 auto;
+	border: solid 1px;
+	border-radius: 50px;
+	padding: 20px;
+	justify-content: center;
+}*/
+.ad-order-status {
+	float: right;
+	margin: 50px 40px 20px 20px;
+	font-size: 16px;
+}
+.ad-tbl-head {
+	margin: 70px 30px 5px 0px;
+}
+.ad-tbl-title3 {
+	font-size: 18px;
+	padding-left: 30px;
+	padding-bottom: 5px;
+	border-bottom: solid 2px;
+	width: 45%;
+}
+.ad-order-info {
+	width: 90%;
+	margin: 0 auto;
+}
+.ad-order-bottom-box {
+	display: flex;
+	flex-direction: row;
+}
+.ad-shipping-address {
+	justify-content: space-between;
+	width: 50%;
+	font-size: 14px;
+	margin-left: 50px;
+}
+.ad-shipping-total{
+	justify-content: space-between;
+	width: 95%;
+	font-size: 20px;
+/*	margin: 20px;*/
+}
+.ad-price-sum {
+	border-bottom: solid 2px;
+	margin-right: 20px;
+}
+.ad-order-user-info {
+	float: right;
+	width: 30%;
+	margin-top: 50px;
+	margin-right: 30px;
+	position: relative;
+}
+.ad-order-user-inner {
+	position: fixed;
+	margin-right: 40px;
+	padding: 10px 30px 10px 30px;
+	border: solid 1px;
+	border-radius: 30px;
+}
+.ad-tbl-title4 {
+	font-size: 14px;
+	padding-bottom: 5px;
+	margin-bottom: 10px;
+	border-bottom: solid 2px;
+	width: 100%;
 }

--- a/app/assets/stylesheets/admins/products.css
+++ b/app/assets/stylesheets/admins/products.css
@@ -1,56 +1,44 @@
-.new-product {
-	margin: 30px;
+.new-product-form {
+	margin-top: 30px;
+	margin-left: 50px;
 }
-.form-horizontal {
-	margin: 30px;
+.add-new-discs {
+	margin-right: 50px;
 }
 
+/*--index--*/
 
-/*--商品一覧--*/
-
-/*	border: solid 1px;
-	border-radius: 5px;
-	background-color: silver;*/
-
-.ad-product-index-box {
+.ad-page {
+	width: 90%;
+	margin: 0 auto;
+}
+.ad-index-box {
 	width: 90%;
 	margin: 30px auto;
 	display: flex;
 	justify-content: center;
 }
-.ad-page-title {
-	width: 90%;
-	margin: 0 auto;
-	padding: 20px;
-}
-.ad-title-btn {
-	width: 150px;
-	text-align: center;
-	margin: 20px auto;
-	border-radius: 30px; /*角の丸み*/
- 	background-color: #EEEEEE; /* 背景色 */
- 	padding: 20px;
- 	font-size: 16px;
+.ad-index-inner {
+	width: 80%;
+	margin: 0px auto;
+	padding-bottom: 30px;
+	border: solid 1px;
+	border-radius: 50px;
+/*	display: flex;
+	flex-direction: row;*/
+	justify-content: center;
 }
 .ad-tbl-title {
 	font-size: 18px;
 /*	position: relative;
 	display: inline-block;*/
 	margin-top: 30px;
-	margin-right: 60%;
+	margin-right: 70%;
+	margin-bottom: 10px;
 	padding-left: 10%;
 	padding-bottom: 5px;
 	border-bottom: solid 2px;
 }
-/*.ad-tbl-top:before {
-	content: '';
-	position: absolute;
-	left: 300%;
-	bottom: -5px;
-	display: inline-block;
-	width: 800px;
-	border-radius: 2px;
-}*/
 .ad-board-title {
 	font-size: 18px;
 	margin: 30px 120px 5px 50px;
@@ -64,24 +52,25 @@
 }
 .box-for-position2 {
 	position: fixed;
-	margin-left: 40px;
+	margin-left: 20px;
 	padding: 10px 10px 10px 30px;
 	border: solid 1px;
 	border-radius: 50px;
 }
 .ad-new-btn {
 	margin-top: 30px;
+	margin-bottom: 10px;
+}
+.add-new-product {
+
 }
 
-/*--商品編集--*/
+/*--edit--*/
 .edit-product {
 	margin: 30px;
 }
-.ad-album-title {
-	font-size: 22px;
-}
 
-/*--商品詳細--*/
+/*--show--*/
 .ad-pro-show-box {
 	position: relative;
 	width: 80%;
@@ -89,46 +78,62 @@
 	display: flex;
 	flex-direction: row;
 }
-.ad-product-info-box {
+.ad-pro-info-box {
 	width: 70%;
 	margin: 10px;
+}
+.ad-pro-info-inner {
+	padding-bottom: 30px;
 	border: solid 1px;
-	border-radius: 5px;
+	border-radius: 50px;
 }
-.sub-info-box {
-	width: 30%;
-	margin-left: 30px;
+.ad-pro-info {
+	margin-left: 80px;
 }
-
-.admin-edit-delete-button{
-	width: 50%;
+.ad-album-title {
+	font-size: 22px;
+}
+.ad-pro-show-btn {
+	width: 80%;
 	margin: 0 auto;
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-end;
 }
-.admin-edit-button{
+/*.admin-edit-button{
 	margin: 5px;
 }
 .admin-delete-button{
 	margin: 5px;
+}*/
+.ad-sub-info-box {
+	width: 30%;
+	margin-top: 50px;
+	margin-left: 30px;
 }
-.admin-product-img{
-	background-color: silver;
-}
-.admin-subtitles{
-	border-bottom: solid 1px;
-	font-size: 20px;
-}
-.admin-product-show-quantity-box{
+.ad-pro-qty-box {
 	height: 200px;
 	margin: 10px;
+	padding-bottom: 10px;
 	border: solid 1px;
-	border-radius: 5px;
+	border-radius: 50px;
 }
-.nearest-orders{
+.ad-sub-info-inner {
+	margin-top: 30px;
+	margin-left: 20px;
+}
+.ad-recent-orders {
 	height: 380px;
 	margin: 10px;
+	padding-bottom: 10px;
 	border: solid 1px;
-	border-radius: 5px;
+	border-radius: 50px;
+}
+.ad-tbl-title5 {
+	font-size: 18px;
+/*	position: relative;
+	display: inline-block;*/
+	margin-top: 30px;
+	margin-right: 30%;
+	margin-bottom: 10px;
+	padding-left: 10%;
+	padding-bottom: 5px;
+	border-bottom: solid 2px;
 }

--- a/app/assets/stylesheets/admins/users.scss
+++ b/app/assets/stylesheets/admins/users.scss
@@ -2,15 +2,16 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-
+/*--header--*/
 .navbar-header {
 	height: 60px;
 }
-span#RealtimeClock {
+#RealtimeClock {
 	size: 4px;
 	color: white;
 	vertical-align: middle;
 }
+
 
 /*--top--*/
 .counter-box {
@@ -40,7 +41,7 @@ span#RealtimeClock {
 }
 .dashboard-box {
 	width: 80%;
-	height: 480px;
+	height: 520px;
 	border: solid 1px;
 	border-radius: 50px;
 	justify-content: center;
@@ -54,12 +55,13 @@ span#RealtimeClock {
 	border-bottom: solid 2px;
 }
 
-/*--ユーザー一覧--*/
+
+/*--index--*/
 .button-group {
 	justify-content: center;
 }
 .ad-user-index-box {
-	width: 80%;
+	width: 90%;
 	margin: 30px auto;
 	display: flex;
 	flex-direction: row;
@@ -73,6 +75,17 @@ span#RealtimeClock {
 	border-radius: 50px;
 	justify-content: center;
 }
+.ad-tbl-title2 {
+	font-size: 18px;
+/*	position: relative;
+	display: inline-block;*/
+	margin-top: 30px;
+	margin-right: 60%;
+	margin-bottom: 10px;
+	padding-left: 10%;
+	padding-bottom: 5px;
+	border-bottom: solid 2px;
+}
 .ad-ad-index-box {
 	width: 30%;
 	margin: 10px;
@@ -81,26 +94,65 @@ span#RealtimeClock {
 .ad-index {
 	font-size: 13px;
 }
-/*--ユーザー詳細--*/
+
+
+/*--show--*/
 .ad-user-show-box {
 	width: 80%;
 	margin:0 auto;
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
+/*	display: flex;*/
+/*	flex-direction: row;*/
 }
-/*.user-show-box {
-	width: 40%;
-	margin: 10px;
-}*/
-.orders-index-box {
-	width: 60%;
-	margin: 10px;
+.ad-user-show-box:after {
+	display: block;
+	clear: both;
+	content: "";
 }
-.button-box {
+.ad-user-show-inner {
+	float: left;
+	width: 480px;
+	margin: 50px 10px 60px 50px;
+	padding-left: 60px;
+}
+.ad-user-info {
+	border: solid 1px;
+	border-radius: 50px;
+}
+.ad-tbl-title2 {
+	font-size: 18px;
+/*	position: relative;
+	display: inline-block;*/
+	margin-top: 30px;
+	margin-right: 55%;
+	margin-bottom: 10px;
+	padding-left: 10%;
+	padding-bottom: 5px;
+	border-bottom: solid 2px;
+}
+.ad-form {
+	margin-left: 80px;
+}
+.ad-user-btn-box {
 	width: 50%;
-    margin: 0 auto;
+    margin: 0 25% 15px;
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+}
+.ad-user-orders {
+	float: right;
+	width: 520px;
+	margin: 50px 30px 50px 10px;
+}
+.ad-user-orders-inner {
+	border: solid 1px;
+	border-radius: 50px;
+/*	margin: 30px 10px;*/
+	padding-bottom: 30px;
+}
+
+
+/*--edit--*/
+.ad-submit-btn {
+	margin-left: 70%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -73,6 +73,8 @@ footer{
 	/*position: fixed;*/
     bottom: 0px;
     left: 0px;
+    clear: both;
+    display: block;
 }
 .flash-message{
 	margin-top: 10px;

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -12,7 +12,7 @@ class Contact < ApplicationRecord
 # end
 
 	belongs_to :order
-	belongs_to :user
+	belongs_to :user, -> { with_deleted }
 
 	has_many :comments
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,5 +1,5 @@
 class Favorite < ApplicationRecord
-	belongs_to :user
+	belongs_to :user, -> { with_deleted }
 	belongs_to :product
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -26,7 +26,7 @@ class Order < ApplicationRecord
 	# belongs_to :address
 	has_one :address
 	accepts_nested_attributes_for :address
-	belongs_to :user
+	belongs_to :user, -> { with_deleted}
 
 	has_many :order_items
 	has_many :products, through: :order_items

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -1,59 +1,61 @@
 <%= render 'admins/users/header'  %>
 
-<div class="ad-order-index-box">
-  <div class="ad-or-index-box">
-    <h4>注文一覧</h4>
+<div class="ad-page">
+
+  <div class="ad-index-box">
+    <div class="ad-index-inner">
       <table class="table table-hover">
-        <thead>
-          <tr>
-            <th></th>
-            <th><%= sort_link(@q, :id, "オーダーNo.") %></th>
-            <th><%= sort_link(@q, :status, "ステータス") %></th>
-            <th></th>
-            <th><%= sort_link(@q, :created_at, "購入日") %></th>
-            <th><%= sort_link(@q, :user_id, "ユーザー名") %></th>
-            <th><%= sort_link(@q, :total, "合計") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @orders.each do |order| %>
-            <%= form_for order, url: admins_order_update_path(order), method: :patch do |f| %>
-              <tr>
-                <th><input type="checkbox"></th>
-                <td><%= link_to admins_order_show_path(order.id) do %>
-                    #<%= order.id %>-<%= order.created_at.strftime('%Y%m%d') %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= @msg %>
-                  <%= order.status %>
-                </td>
-                <td>
-                  <%= f.select :status, Order.statuses.keys.to_a %>
-                  <button type="submit" class="update-button">更新</button>
-                  <% end %>
-                </td>
-                </td>
-                <td><%= order.created_at.strftime('%Y/%m/%d %H:%M') %></td>
-                <%# if admins %>
- <!--                  <td><%#= link_to admins_user_path(order.user.id), method: :get do %>
-                        <%#=order.user.first_name %><%#= order.user.last_name %>
-                      <%# end %></td>
-                <%# else %> -->
-                  <td><%= link_to admins_user_path(order.user.id), method: :get do %>
-                        <%=order.user.first_name %><%= order.user.last_name %>
-                      <% end %></td>
-                <%# end %>
-                <td>¥ <%= order.total %></td>
-              </tr>
-            <% end %>
-        </tbody>
+        <div class="ad-tbl-title2">オーダー一覧</div>
+          <thead>
+            <tr>
+              <th></th>
+              <th><%= sort_link(@q, :id, "オーダーNo.") %></th>
+              <th><%= sort_link(@q, :status, "ステータス") %></th>
+              <th></th>
+              <th><%= sort_link(@q, :created_at, "購入日") %></th>
+              <th><%= sort_link(@q, :user_id, "ユーザー名") %></th>
+              <th><%= sort_link(@q, :total, "合計") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @orders.each do |order| %>
+              <%= form_for order, url: admins_order_update_path(order), method: :patch do |f| %>
+                <tr>
+                  <th><input type="checkbox"></th>
+                  <td><%= link_to admins_order_show_path(order.id) do %>
+                      #<%= order.id %>-<%= order.created_at.strftime('%Y%m%d') %>
+                    <% end %>
+                  </td>
+                  <td>
+                    <%= @msg %>
+                    <%= order.status %>
+                  </td>
+                  <td>
+                    <%= f.select :status, Order.statuses.keys.to_a %>
+                    <button type="submit" class="update-button">更新</button>
+                    <% end %>
+                  </td>
+                  </td>
+                  <td><%= order.created_at.strftime('%Y/%m/%d %H:%M') %></td>
+                  <%# if admins %>
+   <!--                  <td><%#= link_to admins_user_path(order.user.id), method: :get do %>
+                          <%#=order.user.first_name %><%#= order.user.last_name %>
+                        <%# end %></td>
+                  <%# else %> -->
+                    <td><%= link_to admins_user_path(order.user.id), method: :get do %>
+                          <%=order.user.first_name %><%= order.user.last_name %>
+                        <% end %></td>
+                  <%# end %>
+                  <td>¥ <%= order.total %></td>
+                </tr>
+              <% end %>
+          </tbody>
       </table>
       <%= paginate @orders %>
     </div>
 
     <div class="extraction-box">
-      <div class="box_for_position">
+      <div class="box-for-position2">
         <div class="ad-search-box">
           <%= search_form_for @q, url:admins_orders_index_path, method: :get do |f| %>
             <%= f.search_field :id_eq %>

--- a/app/views/admins/orders/show.html.erb
+++ b/app/views/admins/orders/show.html.erb
@@ -1,79 +1,79 @@
 <%= render 'admins/users/header'  %>
-<div class="dashboard-sub">注文詳細</div>
-<div class="user-infomation" style="font-size: 20px;">
-	#<%= @order.id %>-<%= @order.created_at.strftime('%Y%m%d') %>
-</div>
-<div class ="contact-main-box">
-	<div class="contacts-contents">
-		<div class="border-solid-1">
-			<div class= "border-bottom">
-				<div class="order-info2" style="font-size:20px;"><b>注文内容</b></div>
-				<div class="order-status2" style="font-size:20px;"><b>ステータス:</b><%= @order.status %></div>
-				<%= form_for @order, url: admins_order_update2_path(@order), method: :patch do |f| %>
-					<%= f.select :status, Order.statuses.keys.to_a, class: "" %>
-					<%= f.submit "ステータス更新", style: "border-radius: 10px;", class: "btn btn-info" %>
-				<% end %>
-			</div>
-			<div class="order-infomation">
-				<table class="table table-striped table-hover">
-					<thead>
-						<tr>
-							<th>商品</th>
-							<th>価格</th>
-							<th>購入数</th>
-							<th>小計</th>
-						</tr>
-					</thead>
-					<tbody>
-						<% price_sum = 0 %>
-						<% @order_items.each do |order_item| %>
-							<tr>
-								<td>
-									<%= link_to admins_product_path(order_item.product_id) do %>
-										<%= order_item.product.album_title %>
-									<% end %>
-								</td>
-								<td><%= order_item.product.price %></td>
-								<td><%= order_item.quantity %></td>
-								<td><%= order_item.product.price * order_item.quantity %></td>
-							</tr>
-							<% price_sum =  price_sum + order_item.product.price * order_item.quantity %>
-						<% end %>
 
-					</tbody>
-				</table>
+
+<div class ="ad-order-show-box">
+	<div class="ad-order-show-inner">
+		<div class="ad-order-status">
+			<%= form_for @order, url: admins_order_update2_path(@order), method: :patch do |f| %>
+				<%= f.select :status, Order.statuses.keys.to_a, {}, {class: "ad-form-select"} %>
+				<%= f.submit "ステータス更新", style: "border-radius: 10px;", class: "btn btn-default" %>
+			<% end %>
+		</div>
+		<div class= "ad-tbl-head">
+			<div class="ad-tbl-title3">注文内容：<b>#<%= @order.id %>-<%= @order.created_at.strftime('%Y%m%d') %></b>
 			</div>
-			<p>送付先</p>
-			<div class="admin-product-show-total">
-				<div class="address-box">
+		</div>
+		<div class="ad-order-info">
+			<table class="table table-striped table-hover">
+				<thead>
+					<tr>
+						<th>商品</th>
+						<th>価格</th>
+						<th>購入数</th>
+						<th>小計</th>
+					</tr>
+				</thead>
+				<tbody>
+					<% price_sum = 0 %>
+					<% @order_items.each do |order_item| %>
+						<tr>
+							<td>
+								<%= link_to admins_product_path(order_item.product_id) do %>
+									<%= order_item.product.album_title %>
+								<% end %>
+							</td>
+							<td><%= order_item.product.price %></td>
+							<td><%= order_item.quantity %></td>
+							<td><%= order_item.product.price * order_item.quantity %></td>
+						</tr>
+						<% price_sum =  price_sum + order_item.product.price * order_item.quantity %>
+					<% end %>
+
+				</tbody>
+			</table>
+		</div>
+			<div class="ad-order-bottom-box">
+				<div class="ad-shipping-address">
+					<p style="font-size: 14px;">送付先</p>
 					<% if @address != nil %>
-						<div style= "font-size: 20px;">
 						<label>郵便番号：</label><%= @address.postal_code %><br>
 						<label>住所：</label><%= @address.pref %><%= @address.city %><%= @address.address1 %><%= @address.address2 %><br>
 						<label>名前： </label><%= @address.first_name %> <%= @address.last_name %>
 						</div>
 					<% else @address == nil %>
-						<div>
 						郵便番号：<%= @user.postal_code %><br>
 						住所：<%= @user.pref %><%= @user.city %><%= @user.address1 %><%= @user.address2 %><br>
 						名前： <%= @user.first_name %> <%= @user.last_name %>
-						</div>
 					<% end %>
 				</div>
-				<div class="total-box" align="right">
-					<b>合計¥ <%= price_sum %></b>
+				<div class="ad-shipping-total" align="right">
+					<p class="ad-price-sum">
+						合計：<b>¥ <%= price_sum %></b>
+					</p>
 				</div>
 			</div>
 		</div>
 	</div>
-	<div class="order-show-user-box">
-		<p>購入者情報</p>
+	<div class="ad-order-user-info">
+		<div class="ad-order-user-inner">
+		<div class="ad-tbl-title4">購入者情報</div>
 		<div class="">
-			<p><label>ユーザー名：</label>
+			<label>ユーザー名：</label>
 				<%= link_to admins_user_path(@order.user_id)  do %>
-				<%= @order.user.first_name %><%= @order.user.last_name %>
-				<% end %></p>
-			<p><label>E-mail：</label><%= @order.user.email %></p>
+				<%= @order.user.first_name %><%= @order.user.last_name %><br>
+				<% end %>
+			<label>E-mail：</label>
+				<%= @order.user.email %><br>
 		</div>
 	</div>
 </div>

--- a/app/views/admins/products/_disc_fields.html.erb
+++ b/app/views/admins/products/_disc_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields well well-compact">
+<div class="nested-fields well well-compact add-new-discs">
   <div class="form-group">
     <%= f.label "No." %>
     <%= f.number_field :disc_number, min: 1 %>

--- a/app/views/admins/products/index.html.erb
+++ b/app/views/admins/products/index.html.erb
@@ -1,9 +1,9 @@
 <%= render 'admins/users/header'  %>
 
-<div class="container ad-page-title">
+<div class="ad-page">
 
-  <div class="ad-product-index-box">
-    <div class="ad-or-index-box">
+  <div class="ad-index-box">
+    <div class="ad-index-inner">
       	<table class="table table-hover">
           <div class="ad-tbl-title">商品一覧</div>
         		<thead>
@@ -62,7 +62,7 @@
         <% end %>
       </div>
       <div class="ad-new-btn">
-        <%= button_to '新規追加', admins_new_product_path, class: "btn btn-default" %>
+        <%= button_to '新規追加', admins_new_product_path, class: "btn btn-default add-new-product" %>
       </div>
     </div>
   </div>

--- a/app/views/admins/products/new.html.erb
+++ b/app/views/admins/products/new.html.erb
@@ -1,11 +1,11 @@
 <%= render 'admins/users/header'  %>
 
-  <div class="new-product">
-  <h4>新規商品追加</h4>
+  <div class="ad-index-box">
+    <div class="ad-index-inner">
+      <div class="ad-tbl-title">新規商品追加</div>
+      <div class="new-product-form">
 
-    <div class="container">
-
-    	<%= form_for(@product, url: admins_create_product_path) do |f| %>
+    	 <%= form_for(@product, url: admins_create_product_path) do |f| %>
 
         <div class="form-group">
               <%= f.label :artist, "アーティスト名：" %>
@@ -88,6 +88,7 @@
 
 
       <% end %>
+      </div>
 
     </div>
   </div>

--- a/app/views/admins/products/show.html.erb
+++ b/app/views/admins/products/show.html.erb
@@ -2,13 +2,14 @@
 
 
 <div class="ad-pro-show-box">
-		<div class="product-info-box">
-			<p class="admin-subtitles">商品詳細</p>
-			<div class="">
+	<div class="ad-pro-info-box">
+		<div class="ad-pro-info-inner">
+			<p class="ad-tbl-title">商品詳細</p>
+			<div class="ad-pro-info">
 				<p class="ad-album-title"><%= @product.album_title %></p>
 				<p><label>アーティスト：</label><%= @product.artist %></p>
 				<div class="product-img">
-					<%= attachment_image_tag @product, :image, fallback: 'icon-mypage.jpg', :size => "250x250", class: "admin-product-img" %>
+					<%= attachment_image_tag @product, :image, fallback: 'icon-mypage.jpg', :size => "280x280", class: "admin-product-img" %>
 				</div>
 				<p><label>価格 ：¥</label><%= @product.price %></p>
 				<p><label>リリース年：</label><%= @product.release_year %>年</p>
@@ -19,8 +20,9 @@
 				<% else %>
 					<p><label>最終編集日：</label><%= @product.created_at.strftime('%Y年%m月%d日') %></p>
 				<% end %>
+			</div>
 
-				<div class="music-show-box">
+			<div class="music-show-box">
 					<% @product.discs.each do |disc| %>
 						<p>Disc No.<%= disc.disc_number %></p>
 					<table class="table music-table">
@@ -40,27 +42,29 @@
 						</tbody>
 					<% end %>
 					</table>
-				</div>
-					<div class="admin-edit-delete-button">
-						<%= link_to edit_admins_product_path(@product) do %>
-						<button class="admin-edit-button btn-default btn-lg" type="button">編集</button>
-						<% end %>
-						<%= link_to admins_product_path, method: :delete do %>
-						<button class="admin-delete-button btn btn btn-default btn-lg" type="button">削除</button>
-						<% end %>
-					</div>
 			</div>
 		</div>
+	</div>
 
-		<div class="sub-info-box">
-			<div class="ad-pro-box">
-				<p class="admin-subtitles">在庫</p>
-				<p><%= @product.stock %></p>
-				<p class="admin-subtitles">お気に入り</p>
-				<p><%= @product.favorite_count %></p>
+	<div class="ad-sub-info-box">
+
+		<div class="ad-pro-qty-box">
+			<p class="ad-tbl-title2">管理者用</p>
+			<div class="ad-sub-info-inner">
+				<p class="admin-subtitles">在庫：<b><%= @product.stock %></b></p>
+				<p class="admin-subtitles">お気に入り：<b><%= @product.favorite_count %></b></p>
+				<div class="ad-pro-show-btn">
+					<%= link_to edit_admins_product_path(@product) do %>
+						<button class="admin-edit-button btn-default" type="button">商品情報編集</button>
+					<% end %>
+					<%= link_to admins_product_path, method: :delete do %>
+						<button class="admin-delete-button btn-default" type="button">商品削除</button>
+					<% end %>
+				</div>
 			</div>
-			<div class="nearest-orders">
-				<p class="admin-subtitles">最近の注文</p>
+		</div>
+		<div class="ad-recent-orders">
+				<p class="ad-tbl-title5">最近のオーダー</p>
 				<table class="table table-striped table-hover">
 					<thead>
 						<tr>
@@ -84,7 +88,6 @@
 					</tbody>
 				</table>
 				<%= @msg %>
-			</div>
 		</div>
 	</div>
 </div>

--- a/app/views/admins/users/_header.html.erb
+++ b/app/views/admins/users/_header.html.erb
@@ -8,9 +8,11 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <span class="navbar-brand" href="#">
-           BeatPlay
-          </span>
+          <div class="navbar-brand">
+            <%= link_to users_top_path do %>
+            <span><%= image_tag('BeatPlay-logo.png', class: "logo") %></span>
+           <% end %>
+          </div>
           <span id="RealtimeClock"><%= Date.current.strftime('%Y/%m/%d.%a') %></span>
         </div>
 

--- a/app/views/admins/users/edit.html.erb
+++ b/app/views/admins/users/edit.html.erb
@@ -1,15 +1,15 @@
 <%= render 'admins/users/header'  %>
 
-<div class="container">
-	<div class="contents-box row">
-		<h3>ユーザー情報編集</h3>
-		<%= form_for(@user, url: admins_user_path(@user), method: :put) do |f| %>
+<div class="ad-index-box">
+	<div class="ad-index-inner">
+		<div class="ad-tbl-title">ユーザー情報編集</div>
+		  <%= form_for(@user, url: admins_user_path(@user), method: :put) do |f| %>
       <div class="form-horizontal">
 
         <div class="form-group">
           <label class="col-sm-3 control-label">名前：</label>
             <div class="col-sm-8">
-              <%= f.text_field :first_name, autofocus: true %><%= f.text_field :last_name %>
+              <%= f.text_field :first_name, autofocus: true %><%= f.text_field :last_name %><br>
               <%= f.text_field :kana_first %><%= f.text_field :kana_last %>
             </div>
         </div>
@@ -43,9 +43,11 @@
             </div>
         </div>
 
-        <div class="actions">
+        <div class="actions ad-submit-btn">
           <%= f.submit "更新" %>
         </div>
     <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -1,9 +1,10 @@
 <%= render 'admins/users/header'  %>
 
-<div class="ad-user-index-box">
-  <div class="ad-user-ind-box">
-     <table class="table table-hover">
-        <div class="ad-tbl-title">登録ユーザー一覧</div>
+<div class="ad-page">
+  <div class="ad-user-index-box">
+    <div class="ad-user-ind-box">
+      <table class="table table-hover">
+        <div class="ad-tbl-title2">登録ユーザー一覧</div>
          <thead>
           <tr>
             <th><input type="checkbox"></th>
@@ -17,7 +18,7 @@
           </tr>
         </thead>
 
-    <% if @q != nil %>
+      <% if @q != nil %>
 
         <tbody>
           <% @users.each do |user| %>
@@ -36,56 +37,57 @@
           <% end %>
         </tbody>
 
-    <% else %>
+      <% else %>
         <p><%= @msg %></p>
-    <% end %>
+      <% end %>
 
-    </table>
-  </div>
+      </table>
+    </div>
 
 
-  <div class="ad-ad-index-box">
-    <div class="box-for-position2">
-      <h4 class="ad-index">管理者情報</h4>
-        <table class="table table-hover">
-          <thead>
-            <tr>
-              <th>名前</th>
-              <th>Email</th>
-              <th></th>
-              <th></th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @admins.each do |ad| %>
-            <tr>
-              <td><%= ad.name %></td>
-              <td><%= ad.email %></td>
-              <td>
-                <%= button_to "編集", edit_admin_registration_path, method: :get, class: "btn btn-default btn-xs" %>
-              </td>
-              <td>
-                <%= button_to "削除", admin_registration_path, method: :delete, class: "btn btn-default btn-xs", data: { confirm: '削除します。よろしいですか?' }%>
-              </td>
-              <td>
-                <%= button_to '追加', destroy_admin_session_path, method: :delete, class: "btn btn-default btn-xs" %>
-              </td>
-            </tr>
-            <% end %>
-          </tbody>
-        </table>
-
-        <div class="extraction-box">
-          <div class="box_for_position">
-            <div class="ad-search-box">
-              <%= search_form_for @q, url:admins_users_path, method: :get do |f| %>
-                <%= f.search_field :id_eq %>
-                <%= f.submit "ID検索" %>
+    <div class="ad-ad-index-box">
+      <div class="box-for-position2">
+        <h4 class="ad-index">管理者情報</h4>
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th>名前</th>
+                <th>Email</th>
+                <th></th>
+                <th></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @admins.each do |ad| %>
+              <tr>
+                <td><%= ad.name %></td>
+                <td><%= ad.email %></td>
+                <td>
+                  <%= button_to "編集", edit_admin_registration_path, method: :get, class: "btn btn-default btn-xs" %>
+                </td>
+                <td>
+                  <%= button_to "削除", admin_registration_path, method: :delete, class: "btn btn-default btn-xs", data: { confirm: '削除します。よろしいですか?' }%>
+                </td>
+                <td>
+                  <%= button_to '追加', destroy_admin_session_path, method: :delete, class: "btn btn-default btn-xs" %>
+                </td>
+              </tr>
               <% end %>
+            </tbody>
+          </table>
+
+          <div class="extraction-box">
+            <div class="box-for-position">
+              <div class="ad-search-box">
+                <%= search_form_for @q, url:admins_users_path, method: :get do |f| %>
+                  <%= f.search_field :id_eq %>
+                  <%= f.submit "ID検索" %>
+                <% end %>
+              </div>
             </div>
           </div>
-        </div>
+      </div>
     </div>
   </div>
 

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -1,42 +1,46 @@
 <%= render 'admins/users/header'  %>
 
 <div class="ad-user-show-box">
-
-    <div class="form-horizontal user-show-box">
-      <h4>ユーザー登録情報</h4>
-      <div class="form-group">
-          <label>名前：</label>
-          <%= @user.first_name %><%= @user.last_name %>
-        </p>
-      </div>
-      <div class="form-group">
+  <div class="ad-user-show-inner">
+    <div class="ad-user-info">
+      <div class="ad-tbl-title2">ユーザー登録情報</div>
+        <div class="ad-form">
+          <p class="form-control-static">
+            <label>名前：</label>
+              <%= @user.first_name %><%= @user.last_name %>
+          </p>
+        </div>
+        <div class="ad-form">
           <p class="form-control-static">
             <label>住所：</label>
-            <%= @user.postal_code %><br/>
-            <%= @user.pref %> <%= @user.city %>
-            <%= @user.address1 %> <%= @user.address2 %>
+              <%= @user.postal_code %><br/>
+              <%= @user.pref %> <%= @user.city %>
+              <%= @user.address1 %> <%= @user.address2 %>
           </p>
         </div>
-      <div class="form-group">
-          <p class="form-control-static">
-            <label>電話番号：</label>
-            <%= @user.phone_number %>
-          </p>
-      </div>
-      <div class="form-group">
-          <p class="form-control-static">
-            <label>メール：</label>
-            <%= @user.email %>
+        <div class="ad-form">
+            <p class="form-control-static">
+              <label>電話番号：</label>
+              <%= @user.phone_number %>
             </p>
-      </div>
-      <div class="form-group">
-        <div class="button-box">
-          <%= button_to "編集", edit_admins_user_path(@user.id), method: :get, class: "btn btn-default btn-ms" %> <%= button_to "削除", user_registration_path(@user.id), class:"btn btn-default btn-ms", data: { confirm: 'Are you sure?' }, method: :delete %>
         </div>
-      </div>
+        <div class="ad-form">
+            <p class="form-control-static">
+              <label>メール：</label>
+              <%= @user.email %>
+              </p>
+        </div>
+        <div class="ad-form">
+          <div class="ad-user-btn-box">
+            <%= button_to "編集", edit_admins_user_path(@user.id), method: :get, class: "btn btn-default btn-ms" %> <%= button_to "削除", user_registration_path(@user.id), class:"btn btn-default btn-ms", data: { confirm: 'Are you sure?' }, method: :delete %>
+          </div>
+        </div>
     </div>
+  </div>
 
-    <div class="orders-index-box">
+  <div class="ad-user-orders">
+    <div class="ad-user-orders-inner">
+      <div class="ad-tbl-title2">オーダー履歴</div>
       <table class="table">
           <thead>
             <tr>
@@ -57,6 +61,6 @@
             <% end %>
           </tbody>
       </table>
-    </div>
+  </div>
 
 </div>

--- a/app/views/admins/users/top.html.erb
+++ b/app/views/admins/users/top.html.erb
@@ -9,7 +9,7 @@
 
 <div class="dashboard-main-box">
 		<div class="dashboard-box">
-			<p class="dashboard-sub">最新の注文</p>
+			<p class="dashboard-sub">最新のオーダー</p>
 				<table class="table table-striped table-hover">
 						<thead>
 							<tr>


### PR DESCRIPTION
変更点
・論理削除のため、
　orderモデル, contactモデル, favoriteモデルの「belongs_to :user」以降に「, -> { with_deleted }」を追加
・その他、admin側ページの体裁を整えています。