### PR TITLE
bpm検索結果画面にsort_link(並べ替え)を追加

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -125,6 +125,9 @@ td.product-music-data{
     border-radius: 10px;
     padding: 10px 20px;
 }
+.product-image-box{
+	box-shadow: 0px 0px 40px 5px rgba(255, 255, 255, 0.4);
+}
 
 
 /*----------------bpm検索結果一覧-------------------*/

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -80,7 +80,7 @@
 	width: 100%;
 }
 .product-show-box{
-	width: 95%;
+	width: 90%;
 	margin: 0 auto;
 	padding-bottom: 20px;
 }
@@ -88,7 +88,7 @@
 	display: flex;
     flex-direction: row;
     padding-top: 40px;
-    font-size: 20px;
+    font-size: 15px;
 }
 .product-info-box{
 	margin: 70px;
@@ -104,7 +104,7 @@
 	width: 70%;
     margin: 0px auto;
     padding-bottom: 10px;
-    font-size: 17px;
+    font-size: 15px;
 }
 .product-disc-data{
 	margin: 20px;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -183,6 +183,11 @@ p.sign-up{
     color: rgba(255, 255, 255, 0.7);
 }
 
+.users-devise-error-message{
+    color: rgba(255, 255, 255, 0.7);
+    text-align: left;
+}
+
 /*---------------my_page----------------*/
 
 .users-mypage{
@@ -291,6 +296,7 @@ p.sign-up{
 .users-edit-page{
     width: 100%;
     padding: 40px 0;
+    height: 1000px;
 }
 .users-edit-box{
     width: 60%;

--- a/app/views/products/bpms.html.erb
+++ b/app/views/products/bpms.html.erb
@@ -5,6 +5,14 @@
 <%= render 'products/list', q: @q, q2: @q2  %>
 
 <div class="bpm-main-box user-inverse">
+	<div class="sort-box">
+        <div align="center" style="width:200px;border: solid 2px; border-radius:30px; padding:5px; margin-right:5px;" >
+      		<font color="white"><%= sort_link(@q2, :name, " 曲名順", class: "form-control")%></font>
+        </div>
+        <div align="center" style="width:200px;border: solid 2px; border-radius:30px; padding:5px;">
+      		<font color="white"><%= sort_link(@q2, :bpm, "BPM順", class: "form-control")%></font>
+        </div>
+	</div>
 
 	<% if @searchproducts.any? %>
 			<% if @searchproducts2.count != @productall.count %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,7 +7,7 @@
 	<div class="product-show-box">
 		<div class="product-show-image-info-cart-box">
 			<div class="product-image-box">
-				<%= attachment_image_tag @product, :image, :fill, 400, 400, fallback: 'icon-mypage.jpg', :size => "400x400" %>
+				<%= attachment_image_tag @product, :image, :fill, 300, 300, fallback: 'icon-mypage.jpg', :size => "300x300" %>
 			</div>
 			<div class="product-info-box">
 				<p><label>アルバム/シングル名</label> <%= @product.album_title %></p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,7 +7,7 @@
 <!--             -->
 
 <div class="user-inverse" style="padding-top:40px;">
-<div class="users-edit">
+<div class="users-edit-box">
     <div class="">
     	<i class="fa fa-sign-in"></i>
     </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -10,7 +10,7 @@
 
       <div class="sign-up-boxes">
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-          <%= devise_error_messages! %>
+          <div class="users-devise-error-message"><%= devise_error_messages! %></div>
 
           <div class="sign-up-content-box">
             <div class="sign-up-info-name-box">
@@ -37,10 +37,12 @@
             </div>
 
             <div class="sign-up-info-address12-boxes">
+              <label class="sign-up-info-label">番地</label>
               <%= f.text_field :address1, :placeholder => "番地", class: "sign-up-info-box" %>
             </div>
 
-            <div class="sign-up-info-address12-boxes">
+            <div class="sign-up-info-address12-boxes"">
+              <label class="sign-up-info-label">建物名</label>
               <%= f.text_field :address2, :placeholder => "建物名、部屋番号", class: "sign-up-info-box" %>
             </div>
 


### PR DESCRIPTION
bpm検索結果画面にsort_link(並べ替え)を追加し、曲名とbpmで並べ替え検索ができます。
ユーザー編集画面のviewを調整しました。
ユーザー側のdeviseのエラーメッセージの文字色を変更しました。