### PR TITLE
論理削除したuserの表示

### DIFF
--- a/app/assets/stylesheets/admins/users.scss
+++ b/app/assets/stylesheets/admins/users.scss
@@ -94,6 +94,9 @@
 .ad-index {
 	font-size: 13px;
 }
+.ad-user-notice {
+	font-size: 10px;
+}
 
 
 /*--show--*/

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -23,10 +23,14 @@ class Admins::UsersController < ApplicationController
   end
 
   def index
-    @users = User.page(params[:page]).per(30)
+    @users2 = User.all
+    @users = User.with_deleted.page(params[:page]).per(30)
     @admins = Admin.all
+
     @q = User.ransack(params[:q])
-    @users = @q.result
+    @searchuser = @q.result
+    @q2 = User.with_deleted.ransack(params[:q])
+    @searchuser2 = @q2.result
   end
 
   def search
@@ -35,7 +39,7 @@ class Admins::UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.with_deleted.find(params[:id])
   end
 
   def edit

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -37,14 +37,18 @@
                   </td>
                   <td><%= order.created_at.strftime('%Y/%m/%d %H:%M') %></td>
                   <td><%= link_to admins_user_path(order.user.id), method: :get do %>
+                        <% if order.user.deleted_at != nil %>
+                          <%=order.user.first_name %><%= order.user.last_name %>**
+                        <% else %>
                           <%=order.user.first_name %><%= order.user.last_name %>
-
+                        <% end %>
                   </td>
                   <td>¥ <%= order.total %></td>
                 </tr>
               <% end %>
             <% end %>
           </tbody>
+        <div class="ad-user-notice">※名前の脇に「**」がついているユーザーは退会済みです</div>
       </table>
       <%= paginate @orders %>
     </div>
@@ -58,9 +62,9 @@
         <% end %>
         </div>
         <div class="btn-group btn-group-sm status-box" role="group">
-         <button type="button" class="btn btn-default" onclick="OnButton0Click();">出荷待ち</button>
-         <button type="button" class="btn btn-default" onclick="OnButton1Click();">出荷済み</button>
-         <button type="button" class="btn btn-default" onclick="OnButton2Click();"/>お届け済み</button>
+          <button type="button" class="btn btn-default" onclick="OnButton0Click();">出荷待ち</button>
+            <button type="button" class="btn btn-default" onclick="OnButton1Click();">出荷済み</button>
+           <button type="button" class="btn btn-default" onclick="OnButton2Click();"/>お届け済み</button>
         </div>
       </div>
     </div>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -18,10 +18,35 @@
           </tr>
         </thead>
 
-      <% if @q != nil %>
+      <% if @users2.count == @searchuser.count %>
 
         <tbody>
           <% @users.each do |user| %>
+              <tr>
+                <td><input type="checkbox"></td>
+                <td><%= user.id %></td>
+                <td>
+                  <% if user.deleted_at != nil %>
+                    <%= user.first_name %><%= user.last_name %>**
+                  <% else %>
+                    <%= user.first_name %><%= user.last_name %>
+                  <% end %>
+                </td>
+                <td><%= user.email %></td>
+                <td><%= user.created_at.strftime('%Y/%m/%d') %></td>
+                <td><%= button_to "詳細", admins_user_path(user.id), method: :get, class: "btn btn-default btn-ms" %></td>
+                <td><%= button_to "編集", edit_admins_user_path(user.id), method: :get, class: "btn btn-default btn-ms" %></td>
+                <td>
+                  <%= button_to "削除", admins_user_path(user.id), method: :delete, class: "btn btn-default btn-ms", data: { confirm: '削除します。よろしいですか？' }%>
+                </td>
+              </tr>
+          <% end %>
+        </tbody>
+
+      <% else %>
+
+        <tbody>
+          <% @searchuser2.each do |user| %>
           <tr>
             <td><input type="checkbox"></td>
             <td><%= user.id %></td>
@@ -36,10 +61,8 @@
           </tr>
           <% end %>
         </tbody>
-
-      <% else %>
-        <p><%= @msg %></p>
       <% end %>
+      <div class="ad-user-notice">※名前の脇に「**」がついているユーザーは退会済みです</div>
 
       </table>
     </div>

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -5,9 +5,14 @@
     <div class="ad-user-info">
       <div class="ad-tbl-title2">ユーザー登録情報</div>
         <div class="ad-form">
+          <div class="ad-user-notice">※名前の脇に「**」がついているユーザーは退会済みです</div>
           <p class="form-control-static">
             <label>名前：</label>
-              <%= @user.first_name %><%= @user.last_name %>
+              <% if @user.deleted_at != nil %>
+                <%= @user.first_name %><%= @user.last_name %>**
+              <% else %>
+                <%= @user.first_name %><%= @user.last_name %>
+              <% end %>
           </p>
         </div>
         <div class="ad-form">

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -28,7 +28,7 @@
 								<tr>
 									<td class="p-img">
 										<%= link_to product_path(cart_item.product) do %>
-											<%= attachment_image_tag cart_item.product, :image, :fill, 250, 250, fallback: 'icon-mypage.jpg', :size => "250x250", class: "p-img" %>
+											<%= attachment_image_tag cart_item.product, :image, :fill, 250, 250, fallback: 'icon-mypage.png', :size => "250x250", class: "p-img" %>
 										<% end %>
 									</td>
 									<td class="p-info">

--- a/app/views/orders/confirm_user.html.erb
+++ b/app/views/orders/confirm_user.html.erb
@@ -10,7 +10,7 @@
                     <% @cart_items.each_with_index do |cart_item, i| %>
                     <tr>
                     	<td> <%= i+1 %> </td>
-                        <td class="p-img"><%= attachment_image_tag cart_item.product, :image, :fill, 250, 250, fallback: 'icon-mypage.jpg', :size => "250x250", class: "p-img" %></td>
+                        <td class="p-img"><%= attachment_image_tag cart_item.product, :image, :fill, 250, 250, fallback: 'icon-mypage.png', :size => "250x250", class: "p-img" %></td>
                         <td class="p-info">
                             <div>
                                 <p><%= cart_item.product.album_title %></p>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -24,7 +24,7 @@
 			<% @searchproducts.each do |searchproduct| %>
 			<div class="products">
 				<%= link_to product_path(searchproduct) do %>
-					<p class="products-img"><%= attachment_image_tag searchproduct, :image, :fill, 200, 200, fallback: 'icon-mypage.jpg', :size => "200x200" %></p>
+					<p class="products-img"><%= attachment_image_tag searchproduct, :image, :fill, 200, 200, fallback: 'icon-mypage.png', :size => "200x200" %></p>
 				<% end %>
 				<p class="products-info">
 					<%= searchproduct.album_title %><br>
@@ -54,5 +54,5 @@
 </div>
 
 
- <!-- 	ページング　　 -->
+ <!-- 	ページング -->
 </main>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -27,7 +27,7 @@
               <div class="favorites-contents">
                 <%= link_to product_path(favorite.product.id) do %>
                   <div class="favorites-product-image">
-                    <%= attachment_image_tag favorite.product, :image, :fill, 150, 150, fallback: 'icon-mypage.jpg', :size => "150x150" %>
+                    <%= attachment_image_tag favorite.product, :image, :fill, 150, 150, fallback: 'icon-mypage.png', :size => "150x150" %>
                   </div>
                 <% end %>
                 <div class="favorites-product-info-box">
@@ -69,7 +69,7 @@
                   <% order.order_items.each_with_index do |order_item| %>
                     <tr>
                       <td class="orders-product-image">
-                        <%= attachment_image_tag order_item.product, :image, :fill, 100, 100, fallback: 'icon-mypage.jpg', :size => "100x100" %>
+                        <%= attachment_image_tag order_item.product, :image, :fill, 100, 100, fallback: 'icon-mypage.png', :size => "100x100" %>
                       </td>
                       <td class="orders-product-title-artist-box">
                         <p><label>アルバム/シングル名：</label> <%= order_item.product.album_title %></p>


### PR DESCRIPTION
変更点
・admins/users index画面にて退会済みユーザー(論理削除されたユーザー)を表示できるよう修正しました。
　（これまで表示できなかったのは、ransackの検索結果として一覧を表示していたため(デフォルトで検索結果を表示していたため)でした。
　高橋さんご協力の元、deletedを含むすべてのユーザーを表示するパターンと、検索結果を表示するパターンとでif分岐をさせました。
　ご協力ありがとうございました！）
・また、論理削除されたユーザーは名前の横に「**」と表記されるように設定しました。